### PR TITLE
fix: springboot - mybatis 版本不兼容

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>org.mybatis.spring.boot</groupId>
 			<artifactId>mybatis-spring-boot-starter</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>


### PR DESCRIPTION
pom.xml
```
<dependency>
  <groupId>org.mybatis.spring.boot</groupId>
  <artifactId>mybatis-spring-boot-starter</artifactId>
  <version>3.0.4</version>
</dependency>
```